### PR TITLE
fix: change how we scale the entire hierarchy by 0.01 

### DIFF
--- a/src/lib/bvh-converter/convertBVHToVRMAnimation.ts
+++ b/src/lib/bvh-converter/convertBVHToVRMAnimation.ts
@@ -78,10 +78,16 @@ export async function convertBVHToVRMAnimation(
   if (hipsPositionTrack != null && spinePositionTrack != null) {
     const restSpineLength = spineBone.position.length();
     const animSpineLength = _v3A.fromArray(spinePositionTrack.values).length();
-    const restAnimationScaleRatio = restSpineLength / animSpineLength;
+    const restAnimationScaleRatio = animSpineLength / restSpineLength;
 
-    for (let i = 0; i < hipsPositionTrack.values.length; i++) {
-      hipsPositionTrack.values[i] *= restAnimationScaleRatio;
+    if (restAnimationScaleRatio - 1.0 > 1E-6) {
+      const offset = _v3A.copy(hipsBone.position)
+        .multiplyScalar(restAnimationScaleRatio - 1.0)
+        .toArray();
+
+      for (let i = 0; i < hipsPositionTrack.values.length; i ++) {
+        hipsPositionTrack.values[i] -= offset[i % 3];
+      }
     }
   }
 


### PR DESCRIPTION
The spec says that we should not have any scales in the glTF hierarchy.
This now multiplies 0.01 to all bone positions instead.

This PR also addresses the hips position issue that the model levitates on certain BVHs.

See (spec): https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm_animation-1.0/README.md#humanoid
